### PR TITLE
Update ncedc-earthquakes-template.json

### DIFF
--- a/ncedc-earthquakes-template.json
+++ b/ncedc-earthquakes-template.json
@@ -2,7 +2,6 @@
   "template": "ncedc-earthquakes",
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas" : 0,
       "index.refresh_interval": "60s"
     },
     "mappings": {


### PR DESCRIPTION
Rely on the default number of replicas of each deployment instead of forcing it to 0